### PR TITLE
Memory Stuff Added

### DIFF
--- a/dom/webidl/FxOSUService.webidl
+++ b/dom/webidl/FxOSUService.webidl
@@ -12,8 +12,9 @@ interface FxOSUService {
   DOMString recentRxTx();
   DOMString latencyInfo();
   DOMString showLatencyInfo();
+  DOMString memoryManager(); 
   DOMString connectionType();
   DOMString connectionUp();
   DOMString connectionQuality();
-  DOMString mozIsNowGood();
+  DOMString mozIsNowGood(optional DOMString level = "2", optional boolean mustCharge = false);
 };


### PR DESCRIPTION
I really hope I did this correctly!  Memory Stuff should be in my fork.  

use mozFxOSUSever.memoryManger() to return memory usage

To test the observers go to the about:memory page in a new tab and run minimize heap.  You should get log output on the original tab. Still working on a better way to test this.  
